### PR TITLE
Showcase Laratta Labs + bring experience current

### DIFF
--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -7,6 +7,7 @@ export interface Project {
   githubLink?: string
   demoLink?: string
   image?: string
+  studio?: { name: string; url: string }
 }
 
 export const projects: Project[] = [
@@ -39,7 +40,8 @@ export const projects: Project[] = [
       - **Activity Feed:** Squad-based social feed with real-time updates on workouts, achievements, and connections.
     `,
     technologies: ['Swift', 'SwiftUI', 'Node.js', 'TypeScript', 'GraphQL', 'Apollo Server', 'PostgreSQL', 'Prisma ORM', 'Redis', 'WebSockets', 'JWT Auth', 'Sharp', 'Mock Services'],
-    demoLink: 'https://www.supsquadup.com/'
+    demoLink: 'https://www.supsquadup.com/',
+    studio: { name: 'Laratta Labs', url: 'https://larattalabs.com' }
   },
   {
     id: 'project1',

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -37,7 +37,7 @@ const experiences = [
     role: 'Full Stack Engineer',
     org: 'PSIA-AASI',
     period: 'Aug 2025 – Present',
-    location: 'Remote',
+    location: 'Lakewood, CO',
     bullets: [
       'Built an offline-first Progressive Web App (Angular) for on-the-mountain assessment of members pursuing skiing and snowboarding instructor certifications — fully usable without connectivity at altitude, syncing to the backend when back online.',
       'Designed and shipped a member event self-cancellation and refund service end to end (Angular + .NET), with tiered refunds based on days until the event, integrated with the in-house association management system (AMS).',

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -20,6 +20,47 @@ const skills = {
   'Tools & Platforms': ['Rancher', 'Helm', 'Grafana', 'Keycloak', 'Unity'],
 }
 
+const experiences = [
+  {
+    role: 'Founder & Engineer',
+    org: 'Laratta Labs',
+    period: '2026 – Present',
+    location: 'Denver, CO',
+    bullets: [
+      'Run a solo, AI-native software practice — full-stack web and mobile apps, the cloud infrastructure and data pipelines behind them, and AI systems and agents, scoped and shipped to production end to end.',
+      'Designed, built, and shipped SquadUp (a social fitness platform, live on the App Store) and YardPaint (a consumer AI app).',
+    ],
+  },
+  {
+    role: 'Full Stack Engineer',
+    org: 'PSIA-AASI',
+    period: 'Aug 2025 – Present',
+    location: 'Remote',
+    bullets: [
+      'Building a Progressive Web App with offline-first capability for on-the-mountain assessment of members pursuing skiing and snowboarding instructor certifications — fully usable without connectivity and syncing when back online.',
+      'Full-stack ownership across the offline data model, local storage and sync, and the field-facing interface examiners use on-slope.',
+    ],
+  },
+  {
+    role: 'Software Engineer',
+    org: 'Lockheed Martin',
+    period: 'Aug 2022 – Aug 2024',
+    location: 'Littleton, CO',
+    bullets: [
+      'Deployed and managed an internal Kubernetes cluster utilizing Rancher on AWS GovCloud EC2 instances, creating a scalable environment for Docker containerized applications.',
+      'Monitored cluster health using Grafana and Longhorn, responding to incidents with prompt troubleshooting and resolution.',
+      'Took ownership of software and SQL database deployments, becoming the go-to resource for deployment issues and developing new Helm charts.',
+      'Implemented user-configurable data filtering in a C# Unity app, enabling users to customize visual outputs.',
+      'Enhanced GitLab CI/CD pipelines by automating Helm chart linting and deployment, improving consistency and efficiency.',
+      'Deployed and managed Keycloak for role-based access control on a Python application.',
+      'Modified and deployed Dockerfiles eliminating vulnerabilities detected by SAST scans, ensuring security compliance.',
+      'Deployed Docker and Kubernetes (k3s) within air-gapped Red Hat Linux environments using VirtualBox and KVM.',
+      'Authored Linux scripts and documentation for software installation, dependency management, and cluster configuration in restricted networks.',
+      'Thrived in a small Agile team, starting as the sole junior engineer and mentoring multiple new hires.',
+    ],
+  },
+]
+
 export default function About() {
   return (
     <Layout title="About Me | Noah Laratta">
@@ -40,6 +81,21 @@ export default function About() {
             to complex problems. With a bachelor&apos;s degree in Computer Science and years of hands-on
             experience, I&apos;ve developed a deep understanding of software architecture, cloud
             computing, and modern DevOps practices.
+          </motion.p>
+
+          <motion.p variants={fadeUp} className="text-text-secondary leading-relaxed mt-4">
+            Today I run{' '}
+            <a
+              href="https://larattalabs.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary font-medium hover:text-primary-dark transition-colors duration-200"
+            >
+              Laratta Labs
+            </a>
+            , an AI-native software practice in Denver — designing, building, and
+            shipping full-stack products end to end — alongside full-stack
+            engineering for PSIA-AASI.
           </motion.p>
         </motion.div>
 
@@ -90,32 +146,31 @@ export default function About() {
             <div className="w-10 h-0.5 bg-primary mt-2" />
           </motion.div>
 
-          <motion.div variants={fadeUp} className="border-l-2 border-border pl-6 ml-2 relative">
-            {/* Green dot */}
-            <div className="absolute left-[-7px] top-0 w-3 h-3 rounded-full bg-primary" />
-
-            <div>
-              <div className="flex flex-col sm:flex-row sm:items-baseline sm:gap-3 mb-1">
-                <h3 className="text-lg font-semibold text-foreground">Software Engineer</h3>
-                <span className="text-sm text-text-secondary">at Lockheed Martin</span>
-              </div>
-              <p className="text-sm text-text-secondary mb-4">
-                Aug 2022 &ndash; Aug 2024 &middot; Littleton, CO
-              </p>
-              <ul className="space-y-3 text-text-secondary text-sm leading-relaxed">
-                <li>Deployed and managed an internal Kubernetes cluster utilizing Rancher on AWS GovCloud EC2 instances, creating a scalable environment for Docker containerized applications.</li>
-                <li>Monitored cluster health using Grafana and Longhorn, responding to incidents with prompt troubleshooting and resolution.</li>
-                <li>Took ownership of software and SQL database deployments, becoming the go-to resource for deployment issues and developing new Helm charts.</li>
-                <li>Implemented user-configurable data filtering in a C# Unity app, enabling users to customize visual outputs.</li>
-                <li>Enhanced GitLab CI/CD pipelines by automating Helm chart linting and deployment, improving consistency and efficiency.</li>
-                <li>Deployed and managed Keycloak for role-based access control on a Python application.</li>
-                <li>Modified and deployed Dockerfiles eliminating vulnerabilities detected by SAST scans, ensuring security compliance.</li>
-                <li>Deployed Docker and Kubernetes (k3s) within air-gapped Red Hat Linux environments using VirtualBox and KVM.</li>
-                <li>Authored Linux scripts and documentation for software installation, dependency management, and cluster configuration in restricted networks.</li>
-                <li>Thrived in a small Agile team, starting as the sole junior engineer and mentoring multiple new hires.</li>
-              </ul>
-            </div>
-          </motion.div>
+          <div className="space-y-8">
+            {experiences.map((exp) => (
+              <motion.div
+                key={`${exp.org}-${exp.role}`}
+                variants={fadeUp}
+                className="border-l-2 border-border pl-6 ml-2 relative"
+              >
+                <div className="absolute left-[-7px] top-0 w-3 h-3 rounded-full bg-primary" />
+                <div>
+                  <div className="flex flex-col sm:flex-row sm:items-baseline sm:gap-3 mb-1">
+                    <h3 className="text-lg font-semibold text-foreground">{exp.role}</h3>
+                    <span className="text-sm text-text-secondary">at {exp.org}</span>
+                  </div>
+                  <p className="text-sm text-text-secondary mb-4">
+                    {exp.period} &middot; {exp.location}
+                  </p>
+                  <ul className="space-y-3 text-text-secondary text-sm leading-relaxed">
+                    {exp.bullets.map((b, i) => (
+                      <li key={i}>{b}</li>
+                    ))}
+                  </ul>
+                </div>
+              </motion.div>
+            ))}
+          </div>
         </motion.section>
 
         {/* Education */}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -44,7 +44,7 @@ const experiences = [
       'Raised the member-portal and admin frontends to >90% test coverage, then gated deployments on those suites in Azure Pipelines with automated test-result comments on pull requests.',
       'Stood up Claude Code–powered automated PR-review pipelines for the .NET backend and Angular frontends.',
       'Refactored and reworked the monolithic backend billing service for maintainability and correctness.',
-      'Shipped a steady stream of security hardening, performance improvements, and bug fixes across the member and admin experiences — improving accounting accuracy and business automation.',
+      'Shipped a steady stream of security hardening, performance improvements, and bug fixes across the member and admin experiences.',
     ],
   },
   {

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -15,9 +15,11 @@ const fadeUp = {
 }
 
 const skills = {
-  'Languages': ['Java', 'C#', 'Python', 'SQL', 'Bash', 'TypeScript'],
-  'Cloud & DevOps': ['Docker', 'Kubernetes', 'AWS', 'CI/CD', 'GitLab', 'GitHub Actions'],
-  'Tools & Platforms': ['Rancher', 'Helm', 'Grafana', 'Keycloak', 'Unity'],
+  'Languages': ['C#', 'TypeScript', 'Swift', 'Python', 'SQL', 'Java', 'Bash'],
+  'Frameworks & UI': ['Angular', '.NET', 'Next.js / React', 'SwiftUI'],
+  'Cloud & DevOps': ['Azure', 'AWS', 'Docker', 'Kubernetes', 'CI/CD', 'Azure Pipelines', 'GitHub Actions'],
+  'Data & AI': ['MSSQL', 'PostgreSQL', 'Claude / LLMs', 'AI agents', 'MCP'],
+  'Tools & Platforms': ['Helm', 'Grafana', 'Keycloak', 'Rancher'],
 }
 
 const experiences = [
@@ -37,8 +39,12 @@ const experiences = [
     period: 'Aug 2025 – Present',
     location: 'Remote',
     bullets: [
-      'Building a Progressive Web App with offline-first capability for on-the-mountain assessment of members pursuing skiing and snowboarding instructor certifications — fully usable without connectivity and syncing when back online.',
-      'Full-stack ownership across the offline data model, local storage and sync, and the field-facing interface examiners use on-slope.',
+      'Built an offline-first Progressive Web App (Angular) for on-the-mountain assessment of members pursuing skiing and snowboarding instructor certifications — fully usable without connectivity at altitude, syncing to the backend when back online.',
+      'Designed and shipped a member event self-cancellation and refund service end to end (Angular + .NET), with tiered refunds based on days until the event, integrated with the in-house association management system (AMS).',
+      'Raised the member-portal and admin frontends to >90% test coverage, then gated deployments on those suites in Azure Pipelines with automated test-result comments on pull requests.',
+      'Stood up Claude Code–powered automated PR-review pipelines for the .NET backend and Angular frontends.',
+      'Refactored and reworked the monolithic backend billing service for maintainability and correctness.',
+      'Shipped a steady stream of security hardening, performance improvements, and bug fixes across the member and admin experiences — improving accounting accuracy and business automation.',
     ],
   },
   {

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -44,7 +44,7 @@ const experiences = [
       'Raised the member-portal and admin frontends to >90% test coverage, then gated deployments on those suites in Azure Pipelines with automated test-result comments on pull requests.',
       'Stood up Claude Code–powered automated PR-review pipelines for the .NET backend and Angular frontends.',
       'Refactored and reworked the monolithic backend billing service for maintainability and correctness.',
-      'Shipped a steady stream of security hardening, performance improvements, and bug fixes across the member and admin experiences.',
+      'Shipped a steady stream of security hardening, performance improvements, and bug fixes across the member and admin experiences — improving accounting accuracy and business automation.',
     ],
   },
   {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,7 +48,7 @@ export default function Home() {
             variants={fadeUp}
             className="text-lg md:text-xl text-text-secondary mb-10 max-w-2xl leading-relaxed"
           >
-            Software engineer and founder of Laratta Labs, shipping full-stack apps, cloud pipelines, and AI systems.
+            Software engineer and founder of Laratta Labs, shipping full-stack apps, cloud infrastructure, and AI systems.
           </motion.p>
 
           <motion.div
@@ -89,6 +89,8 @@ export default function Home() {
                     <path fill="#B7410E" d="M49 6H33L5 31 3 36v82l2 5 28 25h16v-15H37l-19-18V39l19-18h12V6Z" />
                     <path fill="#6B7280" d="M105 6h16l28 25 2 5v82l-2 5-28 25h-16v-15h12l19-18V39l-19-18h-12V6Z" />
                     <path fill="#F8F7F4" d="M67 46 95 73v9l-28 27-7-7 26-25-26-25 7-6Z" />
+                    <path fill="#6B7280" fillRule="evenodd" d="M77 1a8.5 8.5 0 1 1 0 17 8.5 8.5 0 0 1 0-17Zm0 6.7a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z" />
+                    <path fill="#6B7280" fillRule="evenodd" d="M77 135.5a8.5 8.5 0 1 1 0 17 8.5 8.5 0 0 1 0-17Zm0 6.5a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z" />
                   </svg>
                 </div>
               </div>
@@ -102,7 +104,7 @@ export default function Home() {
                 </h2>
                 <p className="text-text-secondary mt-2 leading-relaxed max-w-2xl">
                   My AI-native software studio in Denver — I design, build, and ship
-                  full-stack apps, cloud pipelines, and AI systems end to end.
+                  full-stack apps, cloud infrastructure, and AI systems end to end.
                   SquadUp and YardPaint are built here.
                 </p>
               </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,7 +48,7 @@ export default function Home() {
             variants={fadeUp}
             className="text-lg md:text-xl text-text-secondary mb-10 max-w-2xl leading-relaxed"
           >
-            Software engineer building scalable solutions with full-stack development, cloud architecture, and DevOps.
+            Software engineer and founder of Laratta Labs, shipping full-stack apps, cloud pipelines, and AI systems.
           </motion.p>
 
           <motion.div
@@ -69,6 +69,58 @@ export default function Home() {
             </Link>
           </motion.div>
         </motion.section>
+
+        {/* Currently — Laratta Labs */}
+        <section className="pb-4">
+          <motion.div
+            initial="initial"
+            whileInView="animate"
+            viewport={{ once: true }}
+            variants={stagger}
+          >
+            <motion.div
+              variants={fadeUp}
+              className="border border-border bg-primary-lighter/20 rounded-2xl p-6 md:p-8 flex flex-col sm:flex-row sm:items-center gap-5 md:gap-7"
+            >
+              {/* Laratta Labs mark — a token from the studio's own brand */}
+              <div className="shrink-0">
+                <div className="w-14 h-14 rounded-xl bg-[#0F1419] flex items-center justify-center">
+                  <svg width="32" height="32" viewBox="0 0 154 154" role="img" aria-label="Laratta Labs">
+                    <path fill="#B7410E" d="M49 6H33L5 31 3 36v82l2 5 28 25h16v-15H37l-19-18V39l19-18h12V6Z" />
+                    <path fill="#6B7280" d="M105 6h16l28 25 2 5v82l-2 5-28 25h-16v-15h12l19-18V39l-19-18h-12V6Z" />
+                    <path fill="#F8F7F4" d="M67 46 95 73v9l-28 27-7-7 26-25-26-25 7-6Z" />
+                  </svg>
+                </div>
+              </div>
+
+              <div className="flex-1">
+                <span className="text-xs font-semibold uppercase tracking-wider text-primary">
+                  Currently
+                </span>
+                <h2 className="text-xl md:text-2xl font-bold text-foreground mt-1">
+                  Building <span className="font-serif text-primary">Laratta Labs</span>
+                </h2>
+                <p className="text-text-secondary mt-2 leading-relaxed max-w-2xl">
+                  My AI-native software studio in Denver — I design, build, and ship
+                  full-stack apps, cloud pipelines, and AI systems end to end.
+                  SquadUp and YardPaint are built here.
+                </p>
+              </div>
+
+              <div className="shrink-0">
+                <a
+                  href="https://larattalabs.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 bg-primary text-white px-6 py-3 rounded-lg font-medium hover:bg-primary-dark transition-colors duration-200 whitespace-nowrap"
+                >
+                  Visit the studio
+                  <span aria-hidden>&rarr;</span>
+                </a>
+              </div>
+            </motion.div>
+          </motion.div>
+        </section>
 
         {/* Featured Projects — Bento Grid */}
         <section className="py-16">
@@ -100,6 +152,11 @@ export default function Home() {
                       <h3 className="text-lg font-semibold text-foreground mb-2">
                         {project.title}
                       </h3>
+                      {project.studio && (
+                        <p className="text-xs text-primary font-medium mb-2">
+                          Built through {project.studio.name}
+                        </p>
+                      )}
                       <p className="text-text-secondary mb-4 leading-relaxed">
                         {project.summary}
                       </p>

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -119,6 +119,11 @@ export default function Projects() {
                   <h3 className="text-base font-semibold text-foreground mb-1.5">
                     {project.title}
                   </h3>
+                  {project.studio && (
+                    <p className="text-[11px] text-primary font-medium mb-1.5">
+                      Built through {project.studio.name}
+                    </p>
+                  )}
                   <p className="text-sm text-text-secondary mb-3 leading-relaxed">
                     {project.summary}
                   </p>
@@ -149,7 +154,20 @@ export default function Projects() {
                   transition={{ duration: 0.3, ease: 'easeOut' }}
                   className="border border-border bg-surface rounded-xl p-8"
                 >
-                  <h2 className="text-2xl font-bold text-foreground mb-4">{selectedProject.title}</h2>
+                  <div className="mb-4">
+                    <h2 className="text-2xl font-bold text-foreground">{selectedProject.title}</h2>
+                    {selectedProject.studio && (
+                      <a
+                        href={selectedProject.studio.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary-dark font-medium mt-1.5 transition-colors duration-200"
+                      >
+                        Built through {selectedProject.studio.name}
+                        <span aria-hidden>↗</span>
+                      </a>
+                    )}
+                  </div>
                   {/* Safe: descriptions are hardcoded in lib/projects.ts, no user input */}
                   <div
                     className="prose prose-sm max-w-none prose-p:text-text-secondary prose-p:leading-relaxed prose-strong:text-foreground prose-li:text-text-secondary prose-li:leading-relaxed prose-ul:my-2"


### PR DESCRIPTION
Adds Laratta Labs presence across the personal site and brings the experience timeline current.

- **Home:** "Currently — Building Laratta Labs" band (full bracket mark badge with rivet dots) linking to larattalabs.com; hero subline now names founder of Laratta Labs; featured SquadUp card credited to the studio. Middle competency reads "cloud infrastructure."
- **About:** Experience refactored to a data-driven list and brought current — Founder & Engineer · Laratta Labs (2026–Present); Full Stack Engineer · PSIA-AASI (Aug 2025–Present, Lakewood CO) covering the offline-first PWA, the event self-cancel/refund service, >90% test coverage + deploy gating, Claude Code PR-review pipelines, and the billing refactor. Bio updated; Skills refreshed (Angular/.NET, Azure, Data & AI).
- **Projects:** "Built through Laratta Labs" credit on SquadUp (list + detail) via a new optional `studio` field.

Game WIP is preserved separately on `wip/verdigris-depths`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
